### PR TITLE
Several method additions and enhancements

### DIFF
--- a/example/Form.NinePatchTestMain.dfm
+++ b/example/Form.NinePatchTestMain.dfm
@@ -2,67 +2,104 @@ object FormNinePatchTestMain: TFormNinePatchTestMain
   Left = 0
   Top = 0
   Caption = 'FormNinePatchTestMain'
-  ClientHeight = 642
-  ClientWidth = 724
+  ClientHeight = 743
+  ClientWidth = 1002
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
-  Font.Height = -11
+  Font.Height = -15
   Font.Name = 'Tahoma'
   Font.Style = []
   OldCreateOrder = False
   Position = poScreenCenter
   OnCreate = FormCreate
-  PixelsPerInch = 96
-  TextHeight = 13
-  object MemoLog: TMemo
-    Left = 20
-    Top = 60
-    Width = 445
-    Height = 109
-    TabOrder = 0
-  end
+  PixelsPerInch = 130
+  TextHeight = 18
   object Image32Board: TImage32
-    Left = 20
-    Top = 184
-    Width = 677
-    Height = 401
+    Left = 0
+    Top = 200
+    Width = 1002
+    Height = 543
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
+    Align = alClient
     Bitmap.ResamplerClassName = 'TNearestResampler'
     BitmapAlign = baTopLeft
     Scale = 1.000000000000000000
     ScaleMode = smNormal
+    TabOrder = 0
+  end
+  object pnlTopbar: TPanel
+    Left = 0
+    Top = 0
+    Width = 1002
+    Height = 49
+    Align = alTop
     TabOrder = 1
+    object Button1: TButton
+      AlignWithMargins = True
+      Left = 480
+      Top = 5
+      Width = 104
+      Height = 39
+      Margins.Left = 4
+      Margins.Top = 4
+      Margins.Right = 4
+      Margins.Bottom = 4
+      Align = alLeft
+      Caption = 'Button1'
+      TabOrder = 0
+      OnClick = Button1Click
+    end
+    object ButtonDraw: TButton
+      AlignWithMargins = True
+      Left = 5
+      Top = 5
+      Width = 237
+      Height = 39
+      Margins.Left = 4
+      Margins.Top = 4
+      Margins.Right = 4
+      Margins.Bottom = 4
+      Align = alLeft
+      Caption = 'Draw Nine-patch Png From File'
+      TabOrder = 1
+      OnClick = ButtonDrawClick
+    end
+    object CheckBoxShowContentArea: TCheckBox
+      AlignWithMargins = True
+      Left = 250
+      Top = 5
+      Width = 222
+      Height = 39
+      Margins.Left = 4
+      Margins.Top = 4
+      Margins.Right = 4
+      Margins.Bottom = 4
+      Align = alLeft
+      Caption = 'ShowContentArea'
+      TabOrder = 2
+    end
   end
-  object ButtonDraw: TButton
-    Left = 20
-    Top = 13
-    Width = 133
-    Height = 25
-    Caption = 'Draw Nine-patch Png'
+  object MemoLog: TMemo
+    Left = 0
+    Top = 49
+    Width = 1002
+    Height = 151
+    Margins.Left = 4
+    Margins.Top = 4
+    Margins.Right = 4
+    Margins.Bottom = 4
+    Align = alTop
+    ScrollBars = ssVertical
     TabOrder = 2
-    OnClick = ButtonDrawClick
-  end
-  object CheckBoxShowContentArea: TCheckBox
-    Left = 212
-    Top = 17
-    Width = 161
-    Height = 17
-    Caption = 'ShowContentArea'
-    TabOrder = 3
-  end
-  object Button1: TButton
-    Left = 528
-    Top = 17
-    Width = 75
-    Height = 25
-    Caption = 'Button1'
-    TabOrder = 4
-    OnClick = Button1Click
   end
   object OpenDialogPNG: TOpenDialog
     DefaultExt = '.png'
     Filter = 'PNG Image|*.png'
-    Left = 384
-    Top = 12
+    Left = 696
+    Top = 84
   end
 end

--- a/example/Form.NinePatchTestMain.pas
+++ b/example/Form.NinePatchTestMain.pas
@@ -95,22 +95,22 @@ procedure TFormNinePatchTestMain.ButtonDrawClick(Sender: TObject);
 var
   FileName: string;
   NinePatch: TNinePatch;
-  Bitmap: TBitmap32;
+  tmpBmp: TBitmap32;
   ContentRect: TRect;
 
   procedure DrawNinePatchImage( AWidth, AHeight, AX, AY: Integer );
   begin
-    Bitmap.SetSize( AWidth, AHeight );
-    NinePatch.DrawTo( Bitmap );
+    tmpBmp.SetSize( AWidth, AHeight );
+    NinePatch.DrawTo( tmpBmp );
 
-    ContentRect := NinePatch.GetContentRect( Bitmap.Width, Bitmap.Height );
+    ContentRect := NinePatch.GetContentRect( tmpBmp.Width, tmpBmp.Height );
     MemoLog.Lines.Add( Format( '[Content Area Info Width: %d Height: %d]', [AWidth, AHeight]) );
     MemoLog.Lines.Add( ContentRect.ToString );
     if CheckBoxShowContentArea.Checked then
-      Bitmap.FillRect( ContentRect.Left, ContentRect.Top, ContentRect.Right, ContentRect.Bottom, clBlack32 );
+      tmpBmp.FillRect( ContentRect.Left, ContentRect.Top, ContentRect.Right, ContentRect.Bottom, clBlack32 );
 
-    Bitmap.DrawMode := dmBlend;
-    Bitmap.DrawTo(Image32Board.Bitmap, AX, AY);
+    tmpBmp.DrawMode := dmBlend;
+    tmpBmp.DrawTo(Image32Board.Bitmap, AX, AY);
   end;
 begin
   if OpenDialogPNG.Execute then
@@ -123,7 +123,7 @@ begin
       begin
         MemoLog.Clear;
 
-        Bitmap := TBitmap32.Create;
+        tmpBmp := TBitmap32.Create;
         try
           // Clear Board
           Image32Board.Bitmap.Width := Image32Board.Width;
@@ -142,7 +142,7 @@ begin
           // Draw Test3
           DrawNinePatchImage( 300, 400, 250, 10 );
         finally
-          Bitmap.Free;
+          tmpBmp.Free;
         end;
       end;
     finally

--- a/example/Form.NinePatchTestMain.pas
+++ b/example/Form.NinePatchTestMain.pas
@@ -5,7 +5,7 @@ interface
 uses
   Winapi.Windows, Winapi.Messages, System.SysUtils, System.Variants, System.Classes, Vcl.Graphics,
   Vcl.Controls, Vcl.Forms, Vcl.Dialogs, GR32, PngImage, Vcl.StdCtrls,
-  GR32_Image;
+  GR32_Image, Vcl.ExtCtrls;
 
 type
   TRectHelper = record helper for TRect
@@ -20,6 +20,7 @@ type
     OpenDialogPNG: TOpenDialog;
     CheckBoxShowContentArea: TCheckBox;
     Button1: TButton;
+    pnlTopbar: TPanel;
     procedure ButtonDrawClick(Sender: TObject);
     procedure FormCreate(Sender: TObject);
     procedure Button1Click(Sender: TObject);
@@ -139,7 +140,7 @@ begin
           DrawNinePatchImage( 200, 100, 0, 150 );
 
           // Draw Test3
-          DrawNinePatchImage( 100, 200, 250, 150 );
+          DrawNinePatchImage( 300, 400, 250, 10 );
         finally
           Bitmap.Free;
         end;

--- a/example/NinePatchTest.dpr
+++ b/example/NinePatchTest.dpr
@@ -1,7 +1,7 @@
 ﻿program NinePatchTest;
 
 uses
-  EMemLeaks,
+  //EMemLeaks,
   Vcl.Forms,
   Form.NinePatchTestMain in 'Form.NinePatchTestMain.pas' {FormNinePatchTestMain},
   NinePatch.Image in '..\src\NinePatch.Image.pas',

--- a/src/NinePatch.Image.pas
+++ b/src/NinePatch.Image.pas
@@ -31,7 +31,8 @@ type
     function GetContentRect( AWidth, AHeight: Integer ): TRect;
 
     function ToString: string; override;
-    
+    function LoadFromStream(const aStream: TStream): Boolean;
+
     property LeftStart: Integer read FLeftStart;
     property LeftEnd: Integer read FLeftEnd;
     property TopStart: Integer read FTopStart;
@@ -254,8 +255,8 @@ function TNinePatch.LoadFromPNGFile(const AFileName: string): Boolean;
 begin
   Result := False;
 
-  if not TPNGUtil.IsNinePatch( AFileName ) then
-    Exit;
+  //  if not TPNGUtil.IsNinePatchFileName( AFileName ) then
+  //    Exit;
 
   if TPNGUtil.PNGFileLoadAndAlphaToBitmap32( AFileName, FBitmap ) then
   begin
@@ -268,6 +269,15 @@ function TNinePatch.ToString: string;
 begin
   Result := Format( 'W: %d, H: %d, Left S: %d E: %d, Top S: %d E: %d, Right S: %d E: %d, Bottom S: %d E: %d',
     [FBitmap.Width, FBitmap.Height, LeftStart, LeftEnd, TopStart, TopEnd, RightStart, RightEnd, BottomStart, BottomEnd] );
+end;
+
+function TNinePatch.LoadFromStream(const aStream: TStream): Boolean;
+begin
+  if TPNGUtil.PNGFileLoadAndAlphaToBitmap32( aStream, FBitmap ) then
+  begin
+    AnalyseNinePatchPoint;
+    Result := True;
+  end;
 end;
 
 { TRectHelper }

--- a/src/NinePatch.Image.pas
+++ b/src/NinePatch.Image.pas
@@ -3,7 +3,7 @@
 interface
 
 uses
-  Windows, Classes, SysUtils, GR32;
+  Windows, Classes, SysUtils, GR32, GR32_Resamplers;
 
 // https://developer.android.com/guide/topics/graphics/2d-graphics.html#nine-patch
 
@@ -32,6 +32,8 @@ type
 
     function ToString: string; override;
     function LoadFromStream(const aStream: TStream): Boolean;
+    function GetOriginalWidth: Integer;
+    function GetOriginalHeight: Integer;
 
     property LeftStart: Integer read FLeftStart;
     property LeftEnd: Integer read FLeftEnd;
@@ -41,6 +43,7 @@ type
     property RightEnd: Integer read FRightEnd;
     property BottomStart: Integer read FBottomStart;
     property BottomEnd: Integer read FBottomEnd;
+    property Bitmap: TBitmap32 read FBitmap;
   end;
 
 implementation
@@ -149,6 +152,8 @@ end;
 constructor TNinePatch.Create;
 begin
   FBitmap := TBitmap32.Create;
+  FBitmap.ResamplerClassName := 'TKernelResampler';
+  TKernelResampler(FBitmap.Resampler).KernelClassName := 'TLanczosKernel';
 end;
 
 destructor TNinePatch.Destroy;
@@ -278,6 +283,18 @@ begin
     AnalyseNinePatchPoint;
     Result := True;
   end;
+end;
+
+function TNinePatch.GetOriginalWidth: Integer;
+begin
+  // A nine-patch PNG has a 1-pixel border on each side
+  Result := FBitmap.Width - 2;
+end;
+
+function TNinePatch.GetOriginalHeight: Integer;
+begin
+  // A nine-patch PNG has a 1-pixel border on each side
+  Result := FBitmap.Height - 2;
 end;
 
 { TRectHelper }

--- a/src/NinePatch.PNGUtil.pas
+++ b/src/NinePatch.PNGUtil.pas
@@ -54,7 +54,6 @@ type
   TRGBByte = record
     B, G, R: byte;
   end;
-
   PRGBArray = ^TRGBArray;
   TRGBArray = array[0..0] of TRGBByte;
 var
@@ -68,24 +67,26 @@ begin
   try
     try
       Png.LoadFromStream( AStream );
-
       ABitmap32.SetSize(Png.Width, Png.Height);
-
       ABitmap32.Clear(SetAlpha(clWhite32, 0));
 
       for Y := 0 to ABitmap32.Height - 1 do
       begin
         AlphaScanLine := Png.AlphaScanline[Y];
         ScanLine := Png.Scanline[Y];
-
-        if not Assigned(ScanLine) then Continue;
+        //        // 2020-02-29: edwin
+        //        Assert(Length(ScanLine^) = ABitmap32.Width,
+        //          'TPNGUtil.PNGFileLoadAndAlphaToBitmap32: Length(ScanLine) <> ABitmap32.Width is WRONG!');
+        if not Assigned(ScanLine) then
+          Continue;
 
         for X := 0 to ABitmap32.Width - 1 do
         begin
           Alpha := 255;
-          if Assigned(AlphaScanLine) then Alpha := AlphaScanLine[X];
-
-          if Alpha <= 0 then Continue;
+          if Assigned(AlphaScanLine) then
+            Alpha := AlphaScanLine[X];
+          if Alpha <= 0 then
+            Continue;
 
           ABitmap32.Pixel[X,Y] := Color32(ScanLine[X].R, ScanLine[X].G, ScanLine[X].B, Alpha);
         end;

--- a/src/NinePatch.PNGUtil.pas
+++ b/src/NinePatch.PNGUtil.pas
@@ -7,7 +7,7 @@ uses
 
 type
   TPNGUtil = record
-    class function IsNinePatch( const AFileName: string ): Boolean; static;
+    class function IsNinePatchFileName(const AFileName: string): Boolean; static;
     class function GetAlpha( AColor: TColor32 ): Byte; static;
     class function PNGFileLoadAndAlphaToBitmap32(const AFileName: String; ABitmap32: TBitmap32): Boolean; overload; static;
     class function PNGFileLoadAndAlphaToBitmap32(AStream: TStream; ABitmap32: TBitmap32): Boolean; overload; static;
@@ -29,7 +29,6 @@ begin
   Stream := TMemoryStream.Create;
   try
     Stream.LoadFromFile( AFileName );
-
     Result := PNGFileLoadAndAlphaToBitmap32( Stream, ABitmap32 );
   finally
     Stream.Free;
@@ -44,7 +43,7 @@ begin
   Result := A;
 end;
 
-class function TPNGUtil.IsNinePatch(const AFileName: string): Boolean;
+class function TPNGUtil.IsNinePatchFileName(const AFileName: string): Boolean;
 begin
   Result := LowerCase( Copy( AFileName, Length(AFileName) - 6 + 1, 6 ) ) = '.9.png';
 end;


### PR DESCRIPTION
- Added: TNinePatch.LoadFromStream
- Added: TNinePatch.GetOriginalWidth and TNinePatch.GetOriginalHeight
- Use TKernelResampler for a better drawing result when the target is a larger bitmap.
- Better naming for the "temp TBitmap32" in TFormNinePatchTestMain.ButtonDrawClick
- Renamed TPNGUtil.IsNinePatch as IsNinePatchFileName and don't call it by default - because we might not always use ".9.png" as the filename extension for the nine-patched PNG images.
- Commented out the use of EMemLeaks unit from within the .dpr file, because it's not commonly available for all  Delphi users.
- Enhanced the control layout of the main form of the demo.
- Minor code formatting for NinePatch.PNGUtil.pas